### PR TITLE
feat(validation): add business rules - required name, valid email, unique email (#4)

### DIFF
--- a/ContactsManager.API/Controllers/ContactController.cs
+++ b/ContactsManager.API/Controllers/ContactController.cs
@@ -60,6 +60,8 @@ public class ContactController : ControllerBase
         _logger.LogInformation("POST /api/contacts email={Email}", dto.Email);
 
         var response = await _contactService.CreateAsync(dto);
+        if (!response.Success)
+            return BadRequest(response);
         return CreatedAtAction(nameof(GetById), new { id = response.Data!.Id }, response);
     }
 
@@ -75,6 +77,8 @@ public class ContactController : ControllerBase
         try
         {
             var response = await _contactService.UpdateAsync(id, dto);
+            if (!response.Success)
+                return BadRequest(response);
             return Ok(response);
         }
         catch (NotFoundException ex)

--- a/ContactsManager.Application/Services/ContactService.cs
+++ b/ContactsManager.Application/Services/ContactService.cs
@@ -63,6 +63,13 @@ public class ContactService : IContactService
     {
         _logger.LogInformation("Creating contact email={Email}", dto.Email);
 
+        var emailExists = await _contactRepository.EmailExistsAsync(dto.Email, null);
+        if (emailExists)
+        {
+            _logger.LogWarning("Create contact failed: email already in use - {Email}", dto.Email);
+            return ApiResponse<ContactDto>.Fail("Email deja utilise.");
+        }
+
         var contact = _mapper.Map<Contact>(dto);
         var created = await _contactRepository.CreateAsync(contact);
 
@@ -81,6 +88,13 @@ public class ContactService : IContactService
         {
             _logger.LogWarning("Contact id={Id} not found for update", id);
             throw new NotFoundException(nameof(Contact), id);
+        }
+
+        var emailExists = await _contactRepository.EmailExistsAsync(dto.Email, id);
+        if (emailExists)
+        {
+            _logger.LogWarning("Update contact id={Id} failed: email already in use - {Email}", id, dto.Email);
+            return ApiResponse<ContactDto>.Fail("Email deja utilise.");
         }
 
         var updated = existing.WithUpdate(dto.Nom, dto.Prenom, dto.Email, dto.Telephone);

--- a/ContactsManager.Domain/Interfaces/IContactRepository.cs
+++ b/ContactsManager.Domain/Interfaces/IContactRepository.cs
@@ -10,4 +10,5 @@ public interface IContactRepository
     Task<Contact> UpdateAsync(Contact contact);
     Task DeleteAsync(int id);
     Task<bool> ExistsAsync(int id);
+    Task<bool> EmailExistsAsync(string email, int? excludeId = null);
 }

--- a/ContactsManager.Infrastructure/Repositories/ContactRepository.cs
+++ b/ContactsManager.Infrastructure/Repositories/ContactRepository.cs
@@ -66,4 +66,11 @@ public class ContactRepository : IContactRepository
             .AsNoTracking()
             .AnyAsync(c => c.Id == id);
     }
+
+    public async Task<bool> EmailExistsAsync(string email, int? excludeId = null)
+    {
+        return await _context.Contacts
+            .AsNoTracking()
+            .AnyAsync(c => c.Email == email && (excludeId == null || c.Id != excludeId));
+    }
 }

--- a/ContactsManager.Tests/Contacts/ContactServiceTests.cs
+++ b/ContactsManager.Tests/Contacts/ContactServiceTests.cs
@@ -94,6 +94,7 @@ public class ContactServiceTests
         var contact = new Contact("Dupont", "Jean", "jean@example.com", "0601020304", 1);
         var dto = new ContactDto(contact.Id, contact.Nom, contact.Prenom, contact.Email, contact.Telephone, contact.UserId, contact.CreatedAt, contact.UpdatedAt);
 
+        _contactRepositoryMock.Setup(r => r.EmailExistsAsync("jean@example.com", null)).ReturnsAsync(false);
         _mapperMock.Setup(m => m.Map<Contact>(createDto)).Returns(contact);
         _contactRepositoryMock.Setup(r => r.CreateAsync(contact)).ReturnsAsync(contact);
         _mapperMock.Setup(m => m.Map<ContactDto>(contact)).Returns(dto);
@@ -103,6 +104,20 @@ public class ContactServiceTests
         result.Success.Should().BeTrue();
         result.Data.Should().NotBeNull();
         result.Data!.Email.Should().Be("jean@example.com");
+    }
+
+    [Test]
+    public async Task CreateAsync_should_return_fail_when_email_already_exists()
+    {
+        var createDto = new CreateContactDto("Dupont", "Jean", "existing@example.com", null, 1);
+
+        _contactRepositoryMock.Setup(r => r.EmailExistsAsync("existing@example.com", null)).ReturnsAsync(true);
+
+        var result = await _contactService.CreateAsync(createDto);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Email deja utilise");
+        _contactRepositoryMock.Verify(r => r.CreateAsync(It.IsAny<Contact>()), Times.Never);
     }
 
     // ---- UpdateAsync ----
@@ -116,6 +131,7 @@ public class ContactServiceTests
         var dto = new ContactDto(updated.Id, updated.Nom, updated.Prenom, updated.Email, updated.Telephone, updated.UserId, updated.CreatedAt, updated.UpdatedAt);
 
         _contactRepositoryMock.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(existing);
+        _contactRepositoryMock.Setup(r => r.EmailExistsAsync("jean@example.com", 1)).ReturnsAsync(false);
         _contactRepositoryMock.Setup(r => r.UpdateAsync(It.IsAny<Contact>())).ReturnsAsync(updated);
         _mapperMock.Setup(m => m.Map<ContactDto>(updated)).Returns(dto);
 
@@ -124,6 +140,22 @@ public class ContactServiceTests
         result.Success.Should().BeTrue();
         result.Data.Should().NotBeNull();
         result.Data!.Prenom.Should().Be("Jean-Pierre");
+    }
+
+    [Test]
+    public async Task UpdateAsync_should_return_fail_when_email_already_used_by_another_contact()
+    {
+        var updateDto = new UpdateContactDto("Dupont", "Jean", "taken@example.com", null);
+        var existing = new Contact("Dupont", "Jean", "jean@example.com", null, 1);
+
+        _contactRepositoryMock.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(existing);
+        _contactRepositoryMock.Setup(r => r.EmailExistsAsync("taken@example.com", 1)).ReturnsAsync(true);
+
+        var result = await _contactService.UpdateAsync(1, updateDto);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Email deja utilise");
+        _contactRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Contact>()), Times.Never);
     }
 
     [Test]

--- a/ContactsManager.Tests/Contacts/ContactValidatorTests.cs
+++ b/ContactsManager.Tests/Contacts/ContactValidatorTests.cs
@@ -1,0 +1,207 @@
+using ContactsManager.Application.DTOs.Contacts;
+using ContactsManager.Application.Validators;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace ContactsManager.Tests.Contacts;
+
+[TestFixture]
+public class ContactValidatorTests
+{
+    private CreateContactDtoValidator _createValidator = null!;
+    private UpdateContactDtoValidator _updateValidator = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _createValidator = new CreateContactDtoValidator();
+        _updateValidator = new UpdateContactDtoValidator();
+    }
+
+    // ---- CreateContactDtoValidator ----
+
+    [Test]
+    public void CreateValidator_should_pass_when_all_fields_valid()
+    {
+        var dto = new CreateContactDto("Dupont", "Jean", "jean@example.com", "0601020304", 1);
+
+        var result = _createValidator.Validate(dto);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void CreateValidator_should_fail_when_nom_empty()
+    {
+        var dto = new CreateContactDto("", "Jean", "jean@example.com", null, 1);
+
+        var result = _createValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Nom" && e.ErrorMessage.Contains("nom"));
+    }
+
+    [Test]
+    public void CreateValidator_should_fail_when_nom_whitespace()
+    {
+        var dto = new CreateContactDto("   ", "Jean", "jean@example.com", null, 1);
+
+        var result = _createValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Nom");
+    }
+
+    [Test]
+    public void CreateValidator_should_fail_when_prenom_empty()
+    {
+        var dto = new CreateContactDto("Dupont", "", "jean@example.com", null, 1);
+
+        var result = _createValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Prenom" && e.ErrorMessage.Contains("prenom"));
+    }
+
+    [Test]
+    public void CreateValidator_should_fail_when_email_invalid_format()
+    {
+        var dto = new CreateContactDto("Dupont", "Jean", "not-an-email", null, 1);
+
+        var result = _createValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Email");
+    }
+
+    [Test]
+    public void CreateValidator_should_fail_when_email_empty()
+    {
+        var dto = new CreateContactDto("Dupont", "Jean", "", null, 1);
+
+        var result = _createValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Email");
+    }
+
+    [Test]
+    public void CreateValidator_should_fail_when_telephone_too_long()
+    {
+        var dto = new CreateContactDto("Dupont", "Jean", "jean@example.com", new string('0', 21), 1);
+
+        var result = _createValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Telephone");
+    }
+
+    [Test]
+    public void CreateValidator_should_pass_when_telephone_null()
+    {
+        var dto = new CreateContactDto("Dupont", "Jean", "jean@example.com", null, 1);
+
+        var result = _createValidator.Validate(dto);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void CreateValidator_should_fail_when_userId_zero()
+    {
+        var dto = new CreateContactDto("Dupont", "Jean", "jean@example.com", null, 0);
+
+        var result = _createValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "UserId");
+    }
+
+    // ---- UpdateContactDtoValidator ----
+
+    [Test]
+    public void UpdateValidator_should_pass_when_all_fields_valid()
+    {
+        var dto = new UpdateContactDto("Dupont", "Jean", "jean@example.com", "0601020304");
+
+        var result = _updateValidator.Validate(dto);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void UpdateValidator_should_fail_when_nom_empty()
+    {
+        var dto = new UpdateContactDto("", "Jean", "jean@example.com", null);
+
+        var result = _updateValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Nom" && e.ErrorMessage.Contains("nom"));
+    }
+
+    [Test]
+    public void UpdateValidator_should_fail_when_nom_whitespace()
+    {
+        var dto = new UpdateContactDto("   ", "Jean", "jean@example.com", null);
+
+        var result = _updateValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Nom");
+    }
+
+    [Test]
+    public void UpdateValidator_should_fail_when_prenom_empty()
+    {
+        var dto = new UpdateContactDto("Dupont", "", "jean@example.com", null);
+
+        var result = _updateValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Prenom" && e.ErrorMessage.Contains("prenom"));
+    }
+
+    [Test]
+    public void UpdateValidator_should_fail_when_email_invalid_format()
+    {
+        var dto = new UpdateContactDto("Dupont", "Jean", "invalid-email", null);
+
+        var result = _updateValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Email");
+    }
+
+    [Test]
+    public void UpdateValidator_should_fail_when_email_empty()
+    {
+        var dto = new UpdateContactDto("Dupont", "Jean", "", null);
+
+        var result = _updateValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Email");
+    }
+
+    [Test]
+    public void UpdateValidator_should_pass_when_telephone_null()
+    {
+        var dto = new UpdateContactDto("Dupont", "Jean", "jean@example.com", null);
+
+        var result = _updateValidator.Validate(dto);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void UpdateValidator_should_fail_when_telephone_too_long()
+    {
+        var dto = new UpdateContactDto("Dupont", "Jean", "jean@example.com", new string('0', 21));
+
+        var result = _updateValidator.Validate(dto);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Telephone");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `EmailExistsAsync(email, excludeId)` to `IContactRepository` and `ContactRepository`
- `ContactService.CreateAsync` checks email uniqueness before insert
- `ContactService.UpdateAsync` checks email uniqueness excluding current contact
- Validators enforce non-empty nom/prenom and valid email format
- Add `ContactValidatorTests` (18 cases) and extend `ContactServiceTests` with email uniqueness cases

Closes #4